### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/build_native/lib/src/third_party/url_dependency.dart
+++ b/build_native/lib/src/third_party/url_dependency.dart
@@ -36,7 +36,8 @@ class WebDependencyUpdater implements DependencyUpdater {
     }
 
     var file = archiveNameFile(directory);
-    var archiveFilename = await file.openRead().transform(utf8.decoder).join();
+    var archiveFilename =
+        await file.openRead().cast<List<int>>().transform(utf8.decoder).join();
     var archiveFile = new File(
         p.join(localBuildNativeDirectory(directory).path, archiveFilename));
 
@@ -68,7 +69,7 @@ class WebDependencyUpdater implements DependencyUpdater {
       }
     }
 
-    var stream = archiveFile.openRead();
+    var stream = archiveFile.openRead().cast<List<int>>();
     var ext = p.extension(archiveFile.path);
     Archive archive;
 
@@ -164,8 +165,11 @@ class WebDependencyUpdater implements DependencyUpdater {
         await rs.pipe(archiveFile.openWrite());
         return true;
       } else {
-        var archiveFilename =
-            await file.openRead().transform(utf8.decoder).join();
+        var archiveFilename = await file
+            .openRead()
+            .cast<List<int>>()
+            .transform(utf8.decoder)
+            .join();
         var archiveFile = new File(
             p.join(localBuildNativeDirectory(directory).path, archiveFilename));
 

--- a/build_native/pubspec.yaml
+++ b/build_native/pubspec.yaml
@@ -2,7 +2,7 @@ author: Tobe O <thosakwe@gmail.com>
 description: Compile native extensions with package:build, using the system compilers.
 homepage: https://github.com/thosakwe/build_native
 name: build_native
-version: 0.0.11
+version: 0.0.11+1
 environment:
   sdk: ">=2.0.0-dev <3.0.0"
 dependencies:


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900