### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/build_native/lib/src/third_party/url_dependency.dart
+++ b/build_native/lib/src/third_party/url_dependency.dart
@@ -161,7 +161,7 @@ class WebDependencyUpdater implements DependencyUpdater {
         file.writeAsString(p.basename(archiveFile.path));
 
         await archiveFile.create(recursive: true);
-        await rs.pipe(archiveFile.openWrite());
+        await rs.cast<List<int>>().pipe(archiveFile.openWrite());
         return true;
       } else {
         var archiveFilename =
@@ -190,7 +190,7 @@ class WebDependencyUpdater implements DependencyUpdater {
         //
         // Let's overwrite the current file, and signal that it needs to be
         // extracted again.
-        await rs.pipe(archiveFile.openWrite());
+        await rs.cast<List<int>>().pipe(archiveFile.openWrite());
         return true;
       }
     } finally {


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900